### PR TITLE
Updated :noindex: with :no-index-entry:

### DIFF
--- a/doc/main/sbs_gui.rst
+++ b/doc/main/sbs_gui.rst
@@ -3,48 +3,48 @@ Segment-by-Segment
 
 .. automodule:: omc3_gui.sbs_gui
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.main_controller
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.main_model
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.main_view
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.measurement_model
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.measurement_view
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.segment_model
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.segment_view
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.defaults
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.help_view
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.plotting
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.segment_by_segment.settings
     :members:
-    :noindex:
+    :no-index-entry:

--- a/doc/modules/plotting.rst
+++ b/doc/modules/plotting.rst
@@ -3,16 +3,16 @@ Plotting
 
 .. automodule:: omc3_gui.plotting.classes
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.plotting.element_lines
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.plotting.latex_to_html
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.plotting.tfs_plotter
     :members:
-    :noindex:
+    :no-index-entry:

--- a/doc/modules/ui.rst
+++ b/doc/modules/ui.rst
@@ -3,58 +3,58 @@ UI-Components
 
 .. automodule:: omc3_gui.ui_components.dataclass_ui
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.dataclass_ui.controller
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.dataclass_ui.model
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.dataclass_ui.view
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.dataclass_ui.tools
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.base_classes_cvm
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.colors
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.file_dialogs
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.item_models
     :members:
-    :noindex:
+    :no-index-entry:
 
 
 .. automodule:: omc3_gui.ui_components.message_boxes
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.styles
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.text_editor
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.threads
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.ui_components.widgets
     :members:
-    :noindex:
+    :no-index-entry:
 

--- a/doc/modules/utils.rst
+++ b/doc/modules/utils.rst
@@ -3,12 +3,12 @@ Utilities
 
 .. automodule:: omc3_gui.utils.counter
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.utils.iteration_classes
     :members:
-    :noindex:
+    :no-index-entry:
 
 .. automodule:: omc3_gui.utils.log_handler
     :members:
-    :noindex:
+    :no-index-entry:


### PR DESCRIPTION
Sphinx released a new update on December 4, 2025 (version [9.0.4](https://pypi.org/project/Sphinx/9.0.4/)).

As part of this update, the documentation has been revised to replace the deprecated :noindex: directive with the new :no-index-entry: directive, enabling dynamic linking of modules.